### PR TITLE
feat:[front] 회원 프로필 수정 (항목 추가)

### DIFF
--- a/core/src/main/kotlin/com/sp/domain/GenericEnumType.kt
+++ b/core/src/main/kotlin/com/sp/domain/GenericEnumType.kt
@@ -1,0 +1,100 @@
+package com.sp.domain
+
+import com.sp.enums.GenericEnum
+import org.hibernate.HibernateException
+import org.hibernate.engine.spi.SharedSessionContractImplementor
+import org.hibernate.usertype.DynamicParameterizedType
+import org.hibernate.usertype.UserType
+import java.io.Serializable
+import java.sql.PreparedStatement
+import java.sql.ResultSet
+import java.sql.SQLException
+import java.sql.Types
+import java.util.*
+
+/**
+ * @author Jaedoo Lee
+ */
+class GenericEnumType : DynamicParameterizedType, UserType {
+
+    companion object {
+        const val NAME = "com.sp.domain.GenericEnumType"
+    }
+
+    private lateinit var enumClass: Class<*>
+
+    override fun setParameterValues(parameters: Properties) {
+        val params = parameters[DynamicParameterizedType.PARAMETER_TYPE] as DynamicParameterizedType.ParameterType
+        enumClass = params.returnedClass
+    }
+
+    override fun sqlTypes(): IntArray {
+        return intArrayOf(Types.VARCHAR)
+    }
+
+    override fun returnedClass(): Class<*>? {
+        return enumClass
+    }
+
+    @Throws(HibernateException::class)
+    override fun equals(x: Any?, y: Any?): Boolean {
+        return x === y
+    }
+
+    @Throws(HibernateException::class)
+    override fun hashCode(x: Any?): Int {
+        return x?.hashCode() ?: 0
+    }
+
+    @Throws(HibernateException::class, SQLException::class)
+    override fun nullSafeGet(
+        rs: ResultSet, names: Array<String>, session: SharedSessionContractImplementor,
+        owner: Any?
+    ): Any? {
+        val value: String? = rs.getString(names[0])
+        return value?.let {
+            enumClass.enumConstants
+                .asSequence()
+                .filterIsInstance<GenericEnum<*>>()
+                .filter { it.value == value }
+                .firstOrNull()
+        }
+    }
+
+    @Throws(HibernateException::class, SQLException::class)
+    override fun nullSafeSet(
+        st: PreparedStatement, value: Any?, index: Int,
+        session: SharedSessionContractImplementor
+    ) {
+        when (value) {
+            null -> st.setNull(index, Types.VARCHAR)
+            !is GenericEnum<*> -> st.setString(index, value as String)
+            else -> st.setString(index, value.value as String)
+        }
+    }
+
+    @Throws(HibernateException::class)
+    override fun deepCopy(value: Any?): Any? {
+        return value
+    }
+
+    override fun isMutable(): Boolean {
+        return false
+    }
+
+    @Throws(HibernateException::class)
+    override fun disassemble(value: Any): Serializable? {
+        return null
+    }
+
+    @Throws(HibernateException::class)
+    override fun assemble(cached: Serializable, owner: Any): Any {
+        return cached
+    }
+
+    @Throws(HibernateException::class)
+    override fun replace(original: Any, target: Any, owner: Any): Any {
+        return original
+    }
+
+}

--- a/core/src/main/kotlin/com/sp/domain/member/entity/Member.kt
+++ b/core/src/main/kotlin/com/sp/domain/member/entity/Member.kt
@@ -2,13 +2,13 @@ package com.sp.domain.member.entity
 
 import com.sp.domain.GenericEnumType
 import com.sp.domain.member.model.MemberRegisterModel
+import com.sp.domain.member.model.MemberUpdateModel
 import com.sp.domain.member.util.MemberPasswordEncryptor
 import com.sp.enums.JoinRoute
 import com.sp.enums.MemberType
 import org.hibernate.annotations.DynamicUpdate
 import org.hibernate.annotations.Type
 import java.time.LocalDateTime
-import com.sp.domain.member.model.MemberUpdateModel
 import javax.persistence.*
 
 /**
@@ -76,7 +76,7 @@ data class Member(
         }
     }
 
-    fun modify(params: MemberUpdateModel) {
+    fun modifyProfile(params: MemberUpdateModel) {
         if (!params.email.isNullOrBlank()) this.email = params.email
         if (!params.newPassword.isNullOrBlank()) this.password = params.newPassword
         if (!params.nickname.isNullOrBlank()) this.nickname = params.nickname

--- a/core/src/main/kotlin/com/sp/domain/member/entity/Member.kt
+++ b/core/src/main/kotlin/com/sp/domain/member/entity/Member.kt
@@ -47,12 +47,15 @@ data class Member(
 
     @Column(name = "last_login_ymdt")
     var lastLoginDateTime: LocalDateTime? = null
+        private set
 
     @Column(name = "update_ymdt")
     var updateDateTime: LocalDateTime? = null
+        private set
 
     @Column(name = "login_count")
     var loginCount: Int = 0
+        private set
 
     companion object {
         fun create(params: MemberRegisterModel) = Member(

--- a/core/src/main/kotlin/com/sp/domain/member/entity/Member.kt
+++ b/core/src/main/kotlin/com/sp/domain/member/entity/Member.kt
@@ -1,12 +1,11 @@
 package com.sp.domain.member.entity
 
-import com.sp.domain.member.model.*
-import com.sp.domain.member.util.*
-import org.hibernate.annotations.*
-import java.time.*
+import com.sp.domain.member.model.MemberRegisterModel
+import com.sp.domain.member.model.MemberUpdateModel
+import com.sp.domain.member.util.MemberPasswordEncryptor
+import org.hibernate.annotations.DynamicUpdate
+import java.time.LocalDateTime
 import javax.persistence.*
-import javax.persistence.Entity
-import javax.persistence.Table
 
 /**
  * @author Jaedoo Lee
@@ -22,10 +21,10 @@ data class Member(
     val no: Long = 0,
 
     @Column(name = "email")
-    val email: String,
+    var email: String,
 
     @Column(name = "password")
-    val password: String,
+    var password: String,
 
     @Column(name = "nickname")
     var nickname: String = ""
@@ -54,8 +53,10 @@ data class Member(
         }
     }
 
-    fun modify(nickname: String) {
-        this.nickname = nickname
+    fun modify(params: MemberUpdateModel) {
+        if (!params.email.isNullOrBlank()) this.email = params.email
+        if (!params.newPassword.isNullOrBlank()) this.password = params.newPassword
+        if (!params.nickname.isNullOrBlank()) this.nickname = params.nickname
         this.updateDateTime = LocalDateTime.now()
     }
 }

--- a/core/src/main/kotlin/com/sp/domain/member/entity/Member.kt
+++ b/core/src/main/kotlin/com/sp/domain/member/entity/Member.kt
@@ -1,12 +1,14 @@
 package com.sp.domain.member.entity
 
-import com.sp.domain.member.model.*
-import com.sp.domain.member.util.*
-import org.hibernate.annotations.*
-import java.time.*
+import com.sp.domain.GenericEnumType
+import com.sp.domain.member.model.MemberRegisterModel
+import com.sp.domain.member.util.MemberPasswordEncryptor
+import com.sp.enums.JoinRoute
+import com.sp.enums.MemberType
+import org.hibernate.annotations.DynamicUpdate
+import org.hibernate.annotations.Type
+import java.time.LocalDateTime
 import javax.persistence.*
-import javax.persistence.Entity
-import javax.persistence.Table
 
 /**
  * @author Jaedoo Lee
@@ -28,21 +30,37 @@ data class Member(
     val password: String,
 
     @Column(name = "nickname")
-    var nickname: String = ""
+    var nickname: String = "",
+
+    @Type(type = GenericEnumType.NAME)
+    @Column(name = "member_type")
+    val memberType: MemberType = MemberType.NORMAL,
+
+    @Type(type = GenericEnumType.NAME)
+    @Column(name = "join_route")
+    val joinRoute: JoinRoute = JoinRoute.PC,
 
 ) {
 
     @Column(name = "join_ymdt")
     val joinDateTime: LocalDateTime = LocalDateTime.now()
 
+    @Column(name = "last_login_ymdt")
+    var lastLoginDateTime: LocalDateTime? = null
+
     @Column(name = "update_ymdt")
     var updateDateTime: LocalDateTime? = null
+
+    @Column(name = "login_count")
+    var loginCount: Int = 0
 
     companion object {
         fun create(params: MemberRegisterModel) = Member(
             email = params.email,
             password = params.password,
-            nickname = params.nickname
+            nickname = params.nickname,
+            memberType = params.memberType,
+            joinRoute = params.joinRoute
         )
     }
 

--- a/core/src/main/kotlin/com/sp/domain/member/model/MemberRegisterModel.kt
+++ b/core/src/main/kotlin/com/sp/domain/member/model/MemberRegisterModel.kt
@@ -1,10 +1,15 @@
 package com.sp.domain.member.model
 
+import com.sp.enums.JoinRoute
+import com.sp.enums.MemberType
+
 /**
  * @author Jaedoo Lee
  */
 data class MemberRegisterModel(
     val email: String,
     val password: String,
-    val nickname: String
+    val nickname: String,
+    val memberType: MemberType,
+    val joinRoute: JoinRoute
 )

--- a/core/src/main/kotlin/com/sp/domain/member/model/MemberUpdateModel.kt
+++ b/core/src/main/kotlin/com/sp/domain/member/model/MemberUpdateModel.kt
@@ -1,0 +1,11 @@
+package com.sp.domain.member.model
+
+/**
+ * @author Jaedoo Lee
+ */
+data class MemberUpdateModel(
+    val no: Long,
+    val email: String?,
+    val nickname: String?,
+    val newPassword: String?
+)

--- a/core/src/main/kotlin/com/sp/enums/DisplayEnum.kt
+++ b/core/src/main/kotlin/com/sp/enums/DisplayEnum.kt
@@ -1,0 +1,10 @@
+package com.sp.enums
+
+/**
+ * @author Jaedoo Lee
+ */
+interface DisplayEnum {
+    val name: String
+    val code: String
+    val label: String
+}

--- a/core/src/main/kotlin/com/sp/enums/GenericEnum.kt
+++ b/core/src/main/kotlin/com/sp/enums/GenericEnum.kt
@@ -1,0 +1,8 @@
+package com.sp.enums
+
+/**
+ * @author Jaedoo Lee
+ */
+interface GenericEnum<V> {
+    val value: V
+}

--- a/core/src/main/kotlin/com/sp/enums/JoinRoute.kt
+++ b/core/src/main/kotlin/com/sp/enums/JoinRoute.kt
@@ -1,0 +1,20 @@
+package com.sp.enums
+
+import com.sp.domain.MessageConverter
+
+/**
+ * @author Jaedoo Lee
+ */
+enum class JoinRoute(
+    override val value: String,
+    override val code: String
+) : GenericEnum<String>, DisplayEnum {
+
+    PC("JIRT0001", "member.join-route.pc"),
+
+    MOBILE_WEB("JIRT0002", "member.join-route.mobile-web"),
+
+    MOBILE_APP("JIRT0003", "member.join-route.mobile-app");
+
+    override val label = MessageConverter.getMessage(code)
+}

--- a/core/src/main/kotlin/com/sp/enums/MemberType.kt
+++ b/core/src/main/kotlin/com/sp/enums/MemberType.kt
@@ -1,0 +1,18 @@
+package com.sp.enums
+
+import com.sp.domain.MessageConverter
+
+/**
+ * @author Jaedoo Lee
+ */
+enum class MemberType(
+    override val value: String,
+    override val code: String
+) : GenericEnum<String>, DisplayEnum {
+
+    NORMAL("MBTP0001", "member.type.normal"),
+
+    NAVER("MBTP0002", "member.type.naver");
+
+    override val label = MessageConverter.getMessage(code)
+}

--- a/flyway/migration/V4__alter_table_add_member_columns.sql
+++ b/flyway/migration/V4__alter_table_add_member_columns.sql
@@ -1,0 +1,5 @@
+ALTER TABLE mb_member
+    ADD member_type char(8) not null,
+    ADD join_route char(8) not null,
+    ADD last_login_ymdt datetime null,
+    ADD login_count int(11) not null;

--- a/front/src/main/kotlin/com/sp/application/member/MemberCommandService.kt
+++ b/front/src/main/kotlin/com/sp/application/member/MemberCommandService.kt
@@ -1,12 +1,14 @@
 package com.sp.application.member
 
-import com.sp.application.auth.*
-import com.sp.domain.*
-import com.sp.domain.member.*
-import com.sp.infrastructure.model.*
-import com.sp.presentation.request.*
-import org.springframework.stereotype.*
-import org.springframework.transaction.support.*
+import com.sp.application.auth.AuthQueryService
+import com.sp.domain.member.DuplicatedEmailException
+import com.sp.domain.member.MemberDomainService
+import com.sp.domain.member.MemberRepository
+import com.sp.domain.member.RequestException
+import com.sp.infrastructure.model.LoginInfoRequest
+import com.sp.presentation.request.LoginRequest
+import org.springframework.stereotype.Service
+import org.springframework.transaction.support.TransactionTemplate
 
 /**
  * @author Jaedoo Lee
@@ -30,7 +32,7 @@ class MemberCommandService(
     suspend fun createToken(params: LoginRequest): String {
         val member = transactionTemplate.execute {
             memberDomainService.checkMemberInfo(params.email)
-        }?: throw RequestException("email : ${params.email}")
+        } ?: throw RequestException("email : ${params.email}")
 
         return member
             .also { it.matchesPassword(params.password) }
@@ -43,7 +45,7 @@ class MemberCommandService(
 
     suspend fun update(params: MemberProfileParams) {
         transactionTemplate.execute {
-            memberDomainService.update(params)
+            memberDomainService.update(params.toModel(), params.oldPassword)
         }
     }
 

--- a/front/src/main/kotlin/com/sp/application/member/MemberProfileParams.kt
+++ b/front/src/main/kotlin/com/sp/application/member/MemberProfileParams.kt
@@ -1,9 +1,21 @@
 package com.sp.application.member
 
+import com.sp.domain.member.model.MemberUpdateModel
+
 /**
  * @author Jaedoo Lee
  */
 data class MemberProfileParams(
     val no: Long,
-    val nickname: String
-)
+    val email: String?,
+    val nickname: String?,
+    val oldPassword: String?,
+    val newPassword: String?
+) {
+    fun toModel() = MemberUpdateModel(
+        no = no,
+        email = email,
+        nickname = nickname,
+        newPassword = newPassword
+    )
+}

--- a/front/src/main/kotlin/com/sp/application/member/MemberRegisterParams.kt
+++ b/front/src/main/kotlin/com/sp/application/member/MemberRegisterParams.kt
@@ -1,6 +1,8 @@
 package com.sp.application.member
 
-import com.sp.domain.member.model.*
+import com.sp.domain.member.model.MemberRegisterModel
+import com.sp.enums.JoinRoute
+import com.sp.enums.MemberType
 
 /**
  * @author Jaedoo Lee
@@ -8,11 +10,15 @@ import com.sp.domain.member.model.*
 data class MemberRegisterParams(
     val email: String,
     val password: String,
-    val nickname: String
+    val nickname: String,
+    val memberType: MemberType,
+    val joinRoute: JoinRoute
 ) {
     fun toModel() = MemberRegisterModel(
         email = email,
         password = password,
-        nickname = nickname
+        nickname = nickname,
+        memberType = memberType,
+        joinRoute = joinRoute
     )
 }

--- a/front/src/main/kotlin/com/sp/domain/member/AbstractMemberFrontExceptions.kt
+++ b/front/src/main/kotlin/com/sp/domain/member/AbstractMemberFrontExceptions.kt
@@ -1,8 +1,9 @@
 package com.sp.domain.member
 
-import com.sp.domain.*
-import com.sp.domain.member.error.*
-import com.sp.domain.member.error.MemberErrorCode.*
+import com.sp.domain.CommonErrorCode
+import com.sp.domain.member.error.MemberErrorCode
+import com.sp.domain.member.error.MemberErrorCode.DUPLICATED_EMAIL
+import com.sp.domain.member.error.MemberErrorCode.INVALID_PASSWORD
 
 /**
  * @author Jaedoo Lee
@@ -14,3 +15,4 @@ abstract class AbstractMemberFrontExceptions(
 
 class RequestException(param: String) : MemberFrontException(CommonErrorCode.REQUEST_ERROR, arrayOf(param))
 class DuplicatedEmailException : AbstractMemberFrontExceptions(DUPLICATED_EMAIL)
+class InvalidPasswordException: AbstractMemberFrontExceptions(INVALID_PASSWORD)

--- a/front/src/main/kotlin/com/sp/domain/member/MemberDomainService.kt
+++ b/front/src/main/kotlin/com/sp/domain/member/MemberDomainService.kt
@@ -1,10 +1,10 @@
 package com.sp.domain.member
 
-import com.sp.application.member.*
-import com.sp.domain.*
-import com.sp.domain.member.entity.*
-import com.sp.domain.member.model.*
-import org.springframework.data.repository.*
+import com.sp.domain.DomainService
+import com.sp.domain.member.entity.Member
+import com.sp.domain.member.model.MemberRegisterModel
+import com.sp.domain.member.model.MemberUpdateModel
+import org.springframework.data.repository.findByIdOrNull
 
 /**
  * @author Jaedoo Lee
@@ -22,12 +22,16 @@ class MemberDomainService(
         return memberRepository.findByEmail(email)
     }
 
-    fun update(params: MemberProfileParams) {
+    fun update(params: MemberUpdateModel, oldPassword: String?) {
         with(params) {
-            memberRepository.findByIdOrNull(no)?.also  {
-                it.modify(nickname)
+            memberRepository.findByIdOrNull(params.no)?.also  {
+                validatePassword(it, oldPassword)
+                it.modify(params)
             } ?: throw RequestException("memberNo : ${no}")
         }
     }
 
+    private fun validatePassword(member: Member, oldPassword: String?) {
+        if (oldPassword != null && !member.matchesPassword(oldPassword)) throw InvalidPasswordException()
+    }
 }

--- a/front/src/main/kotlin/com/sp/domain/member/MemberDomainService.kt
+++ b/front/src/main/kotlin/com/sp/domain/member/MemberDomainService.kt
@@ -26,7 +26,7 @@ class MemberDomainService(
         with(params) {
             memberRepository.findByIdOrNull(params.no)?.also  {
                 validatePassword(it, oldPassword)
-                it.modify(params)
+                it.modifyProfile(params)
             } ?: throw RequestException("memberNo : ${no}")
         }
     }

--- a/front/src/main/kotlin/com/sp/domain/member/error/MemberErrorCode.kt
+++ b/front/src/main/kotlin/com/sp/domain/member/error/MemberErrorCode.kt
@@ -1,6 +1,6 @@
 package com.sp.domain.member.error
 
-import com.sp.domain.*
+import com.sp.domain.ErrorCode
 
 /**
  * @author Jaedoo Lee
@@ -9,6 +9,7 @@ enum class MemberErrorCode(override val simpleCode: String) : ErrorCode {
 
     NO_PERMISSION("M0001"),
     DUPLICATED_EMAIL("M0002"),
+    INVALID_PASSWORD("M0003"),
     TOKEN_EXPIRED("T0001");
     ;
 

--- a/front/src/main/kotlin/com/sp/presentation/request/MemberProfileRequest.kt
+++ b/front/src/main/kotlin/com/sp/presentation/request/MemberProfileRequest.kt
@@ -1,20 +1,33 @@
 package com.sp.presentation.request
 
-import com.sp.application.member.*
-import com.sp.domain.member.*
+import com.sp.application.member.MemberProfileParams
+import com.sp.domain.member.RequestException
 
 /**
  * @author Jaedoo Lee
  */
 data class MemberProfileRequest (
-    val nickname: String,
+    val email: String?,
+    val nickname: String?,
+    val oldPassword: String?,
+    val newPassword: String?
 ) {
     fun toModel(memberNo: Long) = MemberProfileParams(
         no = memberNo,
-        nickname = nickname
+        email = email,
+        nickname = nickname,
+        oldPassword = oldPassword,
+        newPassword = newPassword
     )
 
     fun validate() {
-        if (nickname.isBlank()) throw RequestException("nickname : $nickname")
+        when {
+            email?.isBlank() == true -> throw RequestException("email : $email")
+            nickname?.isBlank() == true -> throw RequestException("nickname : $nickname")
+            oldPassword?.isBlank() == true -> throw RequestException("oldPassword : $oldPassword")
+            newPassword?.isBlank() == true -> throw RequestException("newPassword : $newPassword")
+            oldPassword?.isNotBlank() == true && newPassword.isNullOrBlank() -> throw RequestException("newPassword : $newPassword")
+            newPassword?.isNotBlank() == true && oldPassword.isNullOrBlank() -> throw RequestException("oldPassword : $oldPassword")
+        }
     }
 }

--- a/front/src/main/kotlin/com/sp/presentation/request/MemberRegisterRequest.kt
+++ b/front/src/main/kotlin/com/sp/presentation/request/MemberRegisterRequest.kt
@@ -1,7 +1,9 @@
 package com.sp.presentation.request
 
-import com.sp.application.member.*
-import com.sp.domain.member.util.*
+import com.sp.application.member.MemberRegisterParams
+import com.sp.domain.member.util.MemberPasswordEncryptor
+import com.sp.enums.JoinRoute
+import com.sp.enums.MemberType
 
 /**
  * @author Jaedoo Lee
@@ -9,11 +11,15 @@ import com.sp.domain.member.util.*
 data class MemberRegisterRequest(
     val email: String,
     val password: String,
-    val nickname: String
+    val nickname: String,
+    val memberType: MemberType,
+    val joinRoute: JoinRoute
 ) {
     fun valueOf() = MemberRegisterParams(
         email = email,
         password = MemberPasswordEncryptor.encode(password),
-        nickname = nickname
+        nickname = nickname,
+        memberType = memberType,
+        joinRoute = joinRoute
     )
 }

--- a/front/src/main/resources/messages/error.properties
+++ b/front/src/main/resources/messages/error.properties
@@ -1,5 +1,5 @@
 error.common.E9001={0} 입력이 잘못되었습니다.
 
-error.member.MF001=동일한 이메일 주소로 가입할 수 없습니다.
-
+error.member.M0002=중복된 이메일 주소로 가입할 수 없습니다.
+error.member.M0003=비밀번호가 유효하지 않습니다.
 error.member.T0001=토큰 정보가 만료되었습니다.

--- a/front/src/main/resources/messages/message.properties
+++ b/front/src/main/resources/messages/message.properties
@@ -1,0 +1,6 @@
+member.join-route.pc=PC웹
+member.join-route.mobile-web=모바일웹
+member.join-route.mobile-app=모바일앱
+
+member.type.normal=일반회원
+member.type.naver=네이버회원

--- a/front/src/test/kotlin/com/sp/application/member/MemberCommandServiceTest.kt
+++ b/front/src/test/kotlin/com/sp/application/member/MemberCommandServiceTest.kt
@@ -1,15 +1,20 @@
 package com.sp.application.member
 
-import com.sp.application.auth.*
-import com.sp.domain.member.*
-import com.sp.domain.member.entity.*
+import com.sp.application.auth.AuthQueryService
+import com.sp.domain.member.DuplicatedEmailException
+import com.sp.domain.member.MemberDomainService
+import com.sp.domain.member.MemberRepository
+import com.sp.domain.member.entity.Member
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
-import io.mockk.junit5.*
-import kotlinx.coroutines.*
-import org.junit.jupiter.api.*
-import org.junit.jupiter.api.extension.*
-import org.springframework.transaction.support.*
+import io.mockk.junit5.MockKExtension
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.transaction.support.TransactionCallback
+import org.springframework.transaction.support.TransactionTemplate
 
 /**
  * @author Jaedoo Lee
@@ -95,18 +100,21 @@ internal class MemberCommandServiceTest {
         // given
         val params = MemberProfileParams(
             no = 1L,
-            nickname = "두두"
+            email = "dlwoen9@naver.com",
+            nickname = "두두",
+            oldPassword = "old",
+            newPassword = "new"
         )
 
         // when
-        coEvery { memberDomainService.update(any()) } just runs
+        coEvery { memberDomainService.update(any(), any()) } just runs
         runBlocking {
             memberCommandService.update(params)
         }
 
         // then
         coVerify {
-            memberDomainService.update(any())
+            memberDomainService.update(any(), any())
         }
 
     }

--- a/front/src/test/kotlin/com/sp/application/member/MemberCommandServiceTest.kt
+++ b/front/src/test/kotlin/com/sp/application/member/MemberCommandServiceTest.kt
@@ -1,15 +1,22 @@
 package com.sp.application.member
 
-import com.sp.application.auth.*
-import com.sp.domain.member.*
-import com.sp.domain.member.entity.*
+import com.sp.application.auth.AuthQueryService
+import com.sp.domain.member.DuplicatedEmailException
+import com.sp.domain.member.MemberDomainService
+import com.sp.domain.member.MemberRepository
+import com.sp.domain.member.entity.Member
+import com.sp.enums.JoinRoute
+import com.sp.enums.MemberType
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
-import io.mockk.junit5.*
-import kotlinx.coroutines.*
-import org.junit.jupiter.api.*
-import org.junit.jupiter.api.extension.*
-import org.springframework.transaction.support.*
+import io.mockk.junit5.MockKExtension
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.transaction.support.TransactionCallback
+import org.springframework.transaction.support.TransactionTemplate
 
 /**
  * @author Jaedoo Lee
@@ -47,7 +54,9 @@ internal class MemberCommandServiceTest {
         val params = MemberRegisterParams(
             email = "dlwoen9@naver.com",
             password = "qwert12345",
-            nickname = "두두"
+            nickname = "두두",
+            memberType = MemberType.NORMAL,
+            joinRoute = JoinRoute.PC
         )
 
         // when
@@ -69,7 +78,9 @@ internal class MemberCommandServiceTest {
         val params = MemberRegisterParams(
             email = "dlwoen9@naver.com",
             password = "qwert12345",
-            nickname = "두두"
+            nickname = "두두",
+            memberType = MemberType.NORMAL,
+            joinRoute = JoinRoute.PC
         )
 
         val member = Member(

--- a/front/src/test/kotlin/com/sp/domain/member/MemberDomainServiceTest.kt
+++ b/front/src/test/kotlin/com/sp/domain/member/MemberDomainServiceTest.kt
@@ -1,14 +1,17 @@
 package com.sp.domain.member
 
-import com.sp.application.member.*
-import com.sp.domain.member.entity.*
+import com.sp.domain.member.entity.Member
+import com.sp.domain.member.model.MemberUpdateModel
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
-import io.mockk.junit5.*
-import org.junit.jupiter.api.*
-import org.junit.jupiter.api.extension.*
-import org.springframework.data.repository.*
-import java.time.*
+import io.mockk.junit5.MockKExtension
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.data.repository.findByIdOrNull
+import java.time.LocalDateTime
 
 /**
  * @author Jaedoo Lee
@@ -27,10 +30,14 @@ internal class MemberDomainServiceTest {
     }
 
     @Test
-    fun `회원 정보 수정`() {
-        val params = MemberProfileParams(
+    @DisplayName("oldPassword가 null일 때")
+    fun `회원 정보 수정1`() {
+        val oldPassword = null
+        val params = MemberUpdateModel(
             no = 1L,
-            nickname = "닉네임"
+            email = null,
+            nickname = "닉네임",
+            newPassword = null
         )
 
         val member = mockk<Member> {
@@ -41,15 +48,71 @@ internal class MemberDomainServiceTest {
             every { joinDateTime } returns LocalDateTime.now()
         }
 
-        every { memberRepository.findByIdOrNull(params.no) } returns member
-        every { member.modify(params.nickname) } just runs
+        every { memberRepository.findByIdOrNull(any()) } returns member
+        every { member.modify(any()) } just runs
 
-        memberDomainService.update(params)
+        memberDomainService.update(params, oldPassword)
 
         verify {
-            memberRepository.findByIdOrNull(params.no)
-            member.modify(params.nickname)
+            memberRepository.findByIdOrNull(any())
+            member.modify(any())
         }
     }
 
+    @Test
+    @DisplayName("oldPassword가 있고 일치할 때")
+    fun `회원 정보 수정2`() {
+        val oldPassword = "qwert12345"
+        val params = MemberUpdateModel(
+            no = 1L,
+            email = null,
+            nickname = "닉네임",
+            newPassword = null
+        )
+
+        val member = mockk<Member> {
+            every { no } returns 1L
+            every { email } returns "dlwoen9@naver.com"
+            every { password } returns oldPassword
+            every { nickname } returns "두두두두"
+            every { joinDateTime } returns LocalDateTime.now()
+        }
+
+        every { memberRepository.findByIdOrNull(any()) } returns member
+        every { member.matchesPassword(any()) } returns true
+        every { member.modify(any()) } just runs
+
+        memberDomainService.update(params, oldPassword)
+
+        verify {
+            memberRepository.findByIdOrNull(any())
+            member.matchesPassword(any())
+            member.modify(any())
+        }
+    }
+
+    @Test
+    @DisplayName("oldPassword가 있는데 일치하지 않을 때")
+    fun `회원 정보 수정3`() {
+        val oldPassword = "qwert12345"
+        val params = MemberUpdateModel(
+            no = 1L,
+            email = null,
+            nickname = "닉네임",
+            newPassword = null
+        )
+
+        val member = mockk<Member> {
+            every { no } returns 1L
+            every { email } returns "dlwoen9@naver.com"
+            every { password } returns "hello1234"
+            every { nickname } returns "두두두두"
+            every { joinDateTime } returns LocalDateTime.now()
+        }
+
+        every { memberRepository.findByIdOrNull(any()) } returns member
+        every { member.matchesPassword(any()) } returns false
+
+        assertThrows<InvalidPasswordException> { memberDomainService.update(params, oldPassword) }
+    }
 }

--- a/front/src/test/kotlin/com/sp/domain/member/MemberDomainServiceTest.kt
+++ b/front/src/test/kotlin/com/sp/domain/member/MemberDomainServiceTest.kt
@@ -49,13 +49,13 @@ internal class MemberDomainServiceTest {
         }
 
         every { memberRepository.findByIdOrNull(any()) } returns member
-        every { member.modify(any()) } just runs
+        every { member.modifyProfile(any()) } just runs
 
         memberDomainService.update(params, oldPassword)
 
         verify {
             memberRepository.findByIdOrNull(any())
-            member.modify(any())
+            member.modifyProfile(any())
         }
     }
 
@@ -80,14 +80,14 @@ internal class MemberDomainServiceTest {
 
         every { memberRepository.findByIdOrNull(any()) } returns member
         every { member.matchesPassword(any()) } returns true
-        every { member.modify(any()) } just runs
+        every { member.modifyProfile(any()) } just runs
 
         memberDomainService.update(params, oldPassword)
 
         verify {
             memberRepository.findByIdOrNull(any())
             member.matchesPassword(any())
-            member.modify(any())
+            member.modifyProfile(any())
         }
     }
 

--- a/front/src/test/kotlin/com/sp/domain/member/MemberRepositoryTest.kt
+++ b/front/src/test/kotlin/com/sp/domain/member/MemberRepositoryTest.kt
@@ -1,15 +1,19 @@
 package com.sp.domain.member
 
-import com.sp.domain.member.entity.*
-import org.flywaydb.test.annotation.*
-import org.flywaydb.test.junit5.annotation.*
-import org.junit.jupiter.api.*
-import org.junit.jupiter.api.Assertions.*
-import org.springframework.boot.test.autoconfigure.jdbc.*
-import org.springframework.boot.test.autoconfigure.orm.jpa.*
-import org.springframework.context.annotation.*
-import org.springframework.stereotype.*
-import org.springframework.test.context.*
+import com.sp.domain.member.entity.Member
+import com.sp.enums.JoinRoute
+import com.sp.enums.MemberType
+import org.flywaydb.test.annotation.FlywayTest
+import org.flywaydb.test.junit5.annotation.FlywayTestExtension
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.stereotype.Repository
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestConstructor
 
 /**
  * @author Jaedoo Lee
@@ -31,7 +35,9 @@ class MemberRepositoryTest(
         val request = Member(
             email = "test@naver.com",
             password = "qwert12345",
-            nickname = "두두"
+            nickname = "두두",
+            memberType = MemberType.NORMAL,
+            joinRoute = JoinRoute.PC
         )
 
         //when
@@ -51,7 +57,9 @@ class MemberRepositoryTest(
         val expected = Member(
             email = "test@naver.com",
             password = "qwert12345",
-            nickname = "두두"
+            nickname = "두두",
+            memberType = MemberType.NORMAL,
+            joinRoute = JoinRoute.PC
         )
 
         //when
@@ -68,7 +76,9 @@ class MemberRepositoryTest(
         val expected = Member(
             email = "test@naver.com",
             password = "qwert12345",
-            nickname = "두두"
+            nickname = "두두",
+            memberType = MemberType.NORMAL,
+            joinRoute = JoinRoute.PC
         )
 
         //when

--- a/front/src/test/kotlin/com/sp/presentation/RestDocsExtensions.kt
+++ b/front/src/test/kotlin/com/sp/presentation/RestDocsExtensions.kt
@@ -1,0 +1,10 @@
+package com.sp.presentation
+
+import com.sp.enums.DisplayEnum
+
+/**
+ * @author Jaedoo Lee
+ */
+fun <T : DisplayEnum> Array<T>.toMarkdownList(): String {
+    return joinToString("\n") { "- ${it.name}: ${it.label}" }
+}

--- a/front/src/test/kotlin/com/sp/presentation/handler/MemberHandlerTest.kt
+++ b/front/src/test/kotlin/com/sp/presentation/handler/MemberHandlerTest.kt
@@ -2,6 +2,8 @@ package com.sp.presentation.handler
 
 import com.sp.application.member.MemberCommandService
 import com.sp.domain.extensions.toJson
+import com.sp.enums.JoinRoute
+import com.sp.enums.MemberType
 import com.sp.presentation.request.MemberRegisterRequest
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -47,7 +49,9 @@ internal class MemberHandlerTest {
         val requestBody = MemberRegisterRequest(
             email = "dlwoen9@naver.com",
             password = "qwert12345",
-            nickname = "두두"
+            nickname = "두두",
+            memberType = MemberType.NORMAL,
+            joinRoute = JoinRoute.PC
         )
 
         val request =

--- a/front/src/test/kotlin/com/sp/presentation/request/MemberProfileRequestTest.kt
+++ b/front/src/test/kotlin/com/sp/presentation/request/MemberProfileRequestTest.kt
@@ -1,0 +1,78 @@
+package com.sp.presentation.request
+
+import com.sp.domain.member.RequestException
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+/**
+ * @author Jaedoo Lee
+ */
+internal class MemberProfileRequestTest {
+
+    @Test
+    @DisplayName("email이 빈 값일때")
+    fun `request_검증1`() {
+        val request = MemberProfileRequest(
+            email = "",
+            nickname = "닉네임",
+            oldPassword = "old",
+            newPassword = "new"
+        )
+
+        assertThrows<RequestException> { request.validate() }
+    }
+
+    @Test
+    @DisplayName("email이 null 일때")
+    fun `request_검증2`() {
+        val request = MemberProfileRequest(
+            email = null,
+            nickname = "닉네임",
+            oldPassword = "old",
+            newPassword = "new"
+        )
+
+        assertNotNull(request.validate())
+    }
+
+    @Test
+    @DisplayName("oldPassword값이 있는데 newPassword가 null일 때 ")
+    fun `request_검증3`() {
+        val request = MemberProfileRequest(
+            email = null,
+            nickname = "닉네임",
+            oldPassword = "old",
+            newPassword = null
+        )
+
+        assertThrows<RequestException> { request.validate() }
+    }
+
+    @Test
+    @DisplayName("oldPassword값이 있는데 newPassword가 빈 값일 때 ")
+    fun `request_검증4`() {
+        val request = MemberProfileRequest(
+            email = null,
+            nickname = "닉네임",
+            oldPassword = "old",
+            newPassword = ""
+        )
+
+        assertThrows<RequestException> { request.validate() }
+    }
+
+    @Test
+    @DisplayName("닉네임만 변경")
+    fun `request_검증5`() {
+        val request = MemberProfileRequest(
+            email = null,
+            nickname = "닉네임",
+            oldPassword = null,
+            newPassword = null
+        )
+
+        assertNotNull(request.validate())
+    }
+}

--- a/front/src/test/kotlin/com/sp/presentation/router/MemberRouterTest.kt
+++ b/front/src/test/kotlin/com/sp/presentation/router/MemberRouterTest.kt
@@ -1,24 +1,37 @@
 package com.sp.presentation.router
 
-import com.epages.restdocs.apispec.*
-import com.ninjasquad.springmockk.*
-import com.sp.application.member.*
-import com.sp.presentation.*
-import com.sp.presentation.handler.*
-import com.sp.presentation.request.*
-import com.sp.presentation.response.*
-import io.mockk.*
-import org.junit.jupiter.api.*
-import org.junit.jupiter.api.extension.*
-import org.springframework.boot.test.autoconfigure.web.reactive.*
-import org.springframework.context.*
-import org.springframework.http.*
-import org.springframework.restdocs.*
-import org.springframework.restdocs.payload.*
-import org.springframework.restdocs.payload.PayloadDocumentation.*
-import org.springframework.restdocs.webtestclient.*
-import org.springframework.test.context.*
-import org.springframework.test.web.reactive.server.*
+import com.epages.restdocs.apispec.ResourceDocumentation
+import com.epages.restdocs.apispec.ResourceSnippetParameters
+import com.ninjasquad.springmockk.MockkBean
+import com.sp.application.member.MemberCommandService
+import com.sp.enums.JoinRoute
+import com.sp.enums.MemberType
+import com.sp.presentation.FrontApiTestSupportFilterFunction
+import com.sp.presentation.MemberInfoConstant
+import com.sp.presentation.MemberInfoFilter
+import com.sp.presentation.handler.MemberHandler
+import com.sp.presentation.request.LoginRequest
+import com.sp.presentation.request.MemberProfileRequest
+import com.sp.presentation.request.MemberRegisterRequest
+import com.sp.presentation.response.AccessTokenResponse
+import com.sp.presentation.toMarkdownList
+import io.mockk.coEvery
+import io.mockk.just
+import io.mockk.runs
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
+import org.springframework.context.ApplicationContext
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.restdocs.RestDocumentationContextProvider
+import org.springframework.restdocs.RestDocumentationExtension
+import org.springframework.restdocs.payload.JsonFieldType
+import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
+import org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.web.reactive.server.WebTestClient
 
 /**
  * @author Jaedoo Lee
@@ -51,7 +64,9 @@ internal class MemberRouterTest(private val context: ApplicationContext) {
         val request = MemberRegisterRequest(
             email = "dlwoen9@naver.com",
             password = "qwert12345",
-            nickname = "두두"
+            nickname = "두두",
+            memberType = MemberType.NORMAL,
+            joinRoute = JoinRoute.PC
         )
 
         coEvery { memberCommandService.registerMember(any()) } returns 1L
@@ -71,7 +86,18 @@ internal class MemberRouterTest(private val context: ApplicationContext) {
                     ResourceDocumentation.resource(
                         ResourceSnippetParameters.builder()
                             .tag(TAG)
-                            .description("회원 가입")
+                            .summary("회원 가입")
+                            .description(
+                                """
+                                |## 회원 가입
+                                |
+                                |### memberType : 회원유형
+                                | ${MemberType.values().toMarkdownList()}
+                                | 
+                                |### joinRoute : 가입유형
+                                | ${JoinRoute.values().toMarkdownList()}
+                                |""".trimMargin()
+                            )
                             .requestHeaders(
                                 ResourceDocumentation.headerWithName("Version")
                                     .description("버전")
@@ -85,6 +111,12 @@ internal class MemberRouterTest(private val context: ApplicationContext) {
                                     .type(JsonFieldType.STRING),
                                 fieldWithPath("nickname")
                                     .description("닉네임")
+                                    .type(JsonFieldType.STRING),
+                                fieldWithPath("memberType")
+                                    .description("회원유형")
+                                    .type(JsonFieldType.STRING),
+                                fieldWithPath("joinRoute")
+                                    .description("가입경로")
                                     .type(JsonFieldType.STRING)
                             ).build()
                     )

--- a/front/src/test/kotlin/com/sp/presentation/router/MemberRouterTest.kt
+++ b/front/src/test/kotlin/com/sp/presentation/router/MemberRouterTest.kt
@@ -1,24 +1,34 @@
 package com.sp.presentation.router
 
-import com.epages.restdocs.apispec.*
-import com.ninjasquad.springmockk.*
-import com.sp.application.member.*
-import com.sp.presentation.*
-import com.sp.presentation.handler.*
-import com.sp.presentation.request.*
-import com.sp.presentation.response.*
-import io.mockk.*
-import org.junit.jupiter.api.*
-import org.junit.jupiter.api.extension.*
-import org.springframework.boot.test.autoconfigure.web.reactive.*
-import org.springframework.context.*
-import org.springframework.http.*
-import org.springframework.restdocs.*
-import org.springframework.restdocs.payload.*
-import org.springframework.restdocs.payload.PayloadDocumentation.*
-import org.springframework.restdocs.webtestclient.*
-import org.springframework.test.context.*
-import org.springframework.test.web.reactive.server.*
+import com.epages.restdocs.apispec.ResourceDocumentation
+import com.epages.restdocs.apispec.ResourceSnippetParameters
+import com.ninjasquad.springmockk.MockkBean
+import com.sp.application.member.MemberCommandService
+import com.sp.presentation.FrontApiTestSupportFilterFunction
+import com.sp.presentation.MemberInfoConstant
+import com.sp.presentation.MemberInfoFilter
+import com.sp.presentation.handler.MemberHandler
+import com.sp.presentation.request.LoginRequest
+import com.sp.presentation.request.MemberProfileRequest
+import com.sp.presentation.request.MemberRegisterRequest
+import com.sp.presentation.response.AccessTokenResponse
+import io.mockk.coEvery
+import io.mockk.just
+import io.mockk.runs
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
+import org.springframework.context.ApplicationContext
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.restdocs.RestDocumentationContextProvider
+import org.springframework.restdocs.RestDocumentationExtension
+import org.springframework.restdocs.payload.JsonFieldType
+import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
+import org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.web.reactive.server.WebTestClient
 
 /**
  * @author Jaedoo Lee
@@ -146,7 +156,10 @@ internal class MemberRouterTest(private val context: ApplicationContext) {
     @Test
     fun `회원 정보 수정`() {
         val request = MemberProfileRequest(
-            nickname = "두두루두두"
+            email = null,
+            nickname = "두두루두두",
+            oldPassword = null,
+            newPassword = null
         )
 
         coEvery { memberCommandService.update(any()) } just runs
@@ -167,7 +180,12 @@ internal class MemberRouterTest(private val context: ApplicationContext) {
                         ResourceSnippetParameters.builder()
                             .tag(TAG)
                             .summary("회원 정보 수정")
-                            .description("회원 정보(닉네임) 수정")
+                            .description(
+                                """
+                                |## 회원 정보 수정
+                                |변경할 값만 request로 전송(""은 400 응답)
+                                |""".trimMargin()
+                            )
                             .requestHeaders(
                                 ResourceDocumentation.headerWithName("Version")
                                     .description("버전"),
@@ -175,9 +193,22 @@ internal class MemberRouterTest(private val context: ApplicationContext) {
                                     .description("AccessToken")
                             )
                             .requestFields(
+                                fieldWithPath("email")
+                                    .description("회원 이메일(아이디)")
+                                    .type(JsonFieldType.STRING)
+                                    .optional(),
                                 fieldWithPath("nickname")
                                     .description("회원 닉네임")
-                                    .type(JsonFieldType.STRING),
+                                    .type(JsonFieldType.STRING)
+                                    .optional(),
+                                fieldWithPath("oldPassword")
+                                    .description("기존 비밀번호")
+                                    .type(JsonFieldType.STRING)
+                                    .optional(),
+                                fieldWithPath("newPassword")
+                                    .description("변경할 비밀번호")
+                                    .type(JsonFieldType.STRING)
+                                    .optional(),
                             ).build()
                     )
                 )


### PR DESCRIPTION
기존 회원 프로필 수정 api에 닉네임 항목만 있던 걸
`이메일, 비밀번호`도 변경할 수 있도록 추가
(있으면 수정, 없으면 유지)